### PR TITLE
fix: property typo in product overview

### DIFF
--- a/src/components/ProductsOverview.jsx
+++ b/src/components/ProductsOverview.jsx
@@ -13,7 +13,7 @@ const instructions = [
     alt: "運送說明",
   },
   {
-    href: "/shop/event.png",
+    src: "/shop/event.png",
     alt: "滿額送贈品",
   },
 ];


### PR DESCRIPTION
Fix a typo in product overview resulting in image not showing